### PR TITLE
Bump cibuildwheel to v2.15.0 to automatically build wheels for Python 3.12

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,7 +49,7 @@ jobs:
                   name: sources
 
             - name: Build wheels
-              uses: pypa/cibuildwheel@v2.13.1
+              uses: pypa/cibuildwheel@v2.15.0
               env:
                   # architectures:
                   # - 64-bit linux

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 PACKAGE_NAME = "sqlean"
 SQLEAN_VERSION = "0.21.5"
-VERSION = f"{SQLEAN_VERSION}.1"
+VERSION = f"{SQLEAN_VERSION}.3"
 
 SHORT_DESCRIPTION = "sqlite3 with extensions"
 LONG_DESCRIPTION = Path("README.md").read_text()


### PR DESCRIPTION
Confirmed to work in my fork:

```
7 wheels produced in 7 minutes:
  sqlean.py-0.21.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   2,777 kB
  sqlean.py-0.21.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   2,788 kB
  sqlean.py-0.21.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   2,795 kB
  sqlean.py-0.21.5.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl    2,765 kB
  sqlean.py-0.21.5.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl    2,770 kB
  sqlean.py-0.21.5.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl     2,778 kB
  sqlean.py-0.21.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl     2,775 kB
```

cibuildwheel v2.15.0 release notes: https://github.com/pypa/cibuildwheel/releases/tag/v2.15.0